### PR TITLE
Merge bd to bounded

### DIFF
--- a/epsie/chain/ptchain.py
+++ b/epsie/chain/ptchain.py
@@ -87,6 +87,7 @@ class ParallelTemperedChain(BaseChain):
     chain_id : int or None
         Integer identifying the chain.
     """
+
     def __init__(self, parameters, model, proposals, betas=1., swap_interval=1,
                  adaptive_annealer=None, bit_generator=None, chain_id=0):
         self.parameters = parameters
@@ -124,6 +125,8 @@ class ParallelTemperedChain(BaseChain):
                   bit_generator=self.bit_generator, chain_id=chain_id,
                   beta=beta)
             for beta in self.betas]
+        self.transdimensional = any(chain.transdimensional
+                                    for chain in self.chains)
 
     @property
     def bit_generator(self):
@@ -549,6 +552,9 @@ class ParallelTemperedChain(BaseChain):
                          for swk in swap_index]
         new_stats = [self.chains[swk].current_stats
                      for swk in swap_index]
+        if self.transdimensional:
+            new_active = [self.chains[swk]._active_props
+                          for swk in swap_index]
         if self.hasblobs:
             new_blobs = [self.chains[swk].current_blob
                          for swk in swap_index]
@@ -557,6 +563,8 @@ class ParallelTemperedChain(BaseChain):
         for (tk, chain) in enumerate(self.chains):
             chain._positions[ii] = new_positions[tk]
             chain._stats[ii] = new_stats[tk]
+            if self.transdimensional:
+                chain._active_props = new_active[tk]
             if self.hasblobs:
                 chain._blobs[ii] = new_blobs[tk]
         self._temperature_acceptance[ii//self.swap_interval] = {

--- a/epsie/proposals/__init__.py
+++ b/epsie/proposals/__init__.py
@@ -28,6 +28,8 @@ from .discrete import (NormalDiscrete, SSAdaptiveNormalDiscrete,
                        AdaptiveNormalDiscrete,
                        BoundedDiscrete, SSAdaptiveBoundedDiscrete,
                        AdaptiveBoundedDiscrete)
+from .nested_transdimensional import (NestedTransdimensional,
+                                      UniformBirthDistribution)
 
 
 proposals = {
@@ -47,5 +49,7 @@ proposals = {
     BoundedDiscrete.name: BoundedDiscrete,
     SSAdaptiveBoundedDiscrete.name: SSAdaptiveBoundedDiscrete,
     AdaptiveBoundedDiscrete.name: AdaptiveBoundedDiscrete,
+    NestedTransdimensional.name: NestedTransdimensional,
     AdaptiveProposal.name: AdaptiveProposal,
+    UniformBirthDistribution.name: UniformBirthDistribution,
 }

--- a/epsie/proposals/adaptive_proposal.py
+++ b/epsie/proposals/adaptive_proposal.py
@@ -114,44 +114,45 @@ class AdaptiveProposalSupport(object):
         self._decay_const = (adaptation_duration)**(-0.6)
         self._adaptation_duration = adaptation_duration
 
-    def decay(self, iteration):
-        """Adaptive decay to ensure vanishing adaptation."""
-        return (iteration - self.start_iter + 1)**(-0.6) - self._decay_const
-
     def update(self, chain):
         """Updates the adaptation based on whether the last jump was accepted.
         This prepares the proposal for the next jump.
         """
-        if 0 < chain.iteration - self.start_iter < (self.adaptation_duration):
-            decay = self.decay(chain.iteration)
+        dk = self.nsteps - self.start_iter
+        if 1 < dk < self.adaptation_duration:
+            dk = dk**(-0.6) - self._decay_const
             newpt = numpy.array([chain.current_position[p]
                                  for p in self.parameters])
             # Update the first moment
             df = newpt - self._mean
-            self._mean = self._mean + decay * df
+            self._mean = self._mean + dk * df
             # Update the second moment
             df = df.reshape(-1, 1)
-            self._unit_cov += decay * (numpy.matmul(df, df.T) - self._unit_cov)
+            self._unit_cov += dk * (numpy.matmul(df, df.T) - self._unit_cov)
             # Update of the global scaling
             ar = min(1, chain.acceptance['acceptance_ratio'][-1])
-            self._log_lambda += decay * (ar - self.target_acceptance)
+            self._log_lambda += dk * (ar - self.target_acceptance)
 
             self.cov = numpy.exp(self._log_lambda) * self._unit_cov
+        # don't forget to increment this
+        self.nsteps += 1
 
     @property
     def state(self):
         return {'random_state': self.random_state,
                 'mean': self._mean,
-                'cov': self._cov,
+                'cov': self.cov,
                 'unit_cov': self._unit_cov,
-                'log_lambda': self._log_lambda}
+                'log_lambda': self._log_lambda,
+                'nsteps': self._nsteps}
 
     def set_state(self, state):
         self.random_state = state['random_state']
         self._mean = state['mean']
-        self._cov = state['cov']
+        self.cov = state['cov']
         self._unit_cov = state['unit_cov']
         self._log_lambda = state['log_lambda']
+        self._nsteps = state['nsteps']
 
 
 class AdaptiveProposal(AdaptiveProposalSupport, Normal):

--- a/epsie/proposals/base.py
+++ b/epsie/proposals/base.py
@@ -58,6 +58,7 @@ class BaseProposal(object):
     """
     name = None
     _parameters = None
+    _nsteps = None
 
     @property
     def bit_generator(self):
@@ -135,6 +136,22 @@ class BaseProposal(object):
         if isinstance(parameters, six.string_types):
             parameters = [parameters]
         self._parameters = tuple(parameters)
+
+    @property
+    def nsteps(self):
+        """Returns number of update iterations with this proposal. While
+        for a standard adaptive MCMC this will match the length of the chain
+        for a transdimensional proposal it will differ."""
+        if self._nsteps is None:
+            self._nsteps = 1  # not 0 because this gets updated after the move
+        return self._nsteps
+
+    @nsteps.setter
+    def nsteps(self, nsteps):
+        """Sets the new number of steps done with a proposal"""
+#        if self.nsteps is None:
+#            self._nsteps = 1
+        self._nsteps = nsteps
 
     # Py3XX: uncomment the next two lines
     # @property

--- a/epsie/proposals/joint.py
+++ b/epsie/proposals/joint.py
@@ -79,7 +79,10 @@ class JointProposal(BaseProposal):
         out = {}
         for prop in self.proposals:
             # we'll only pass the parameters that the proposal needs
-            out.update(prop.jump({p: fromx[p] for p in prop.parameters}))
+            point = {p: fromx[p] for p in prop.parameters}
+            if prop.transdimensional:
+                point.update({'_state': fromx['_state']})
+            out.update(prop.jump(point))
         return out
 
     @property

--- a/epsie/proposals/nested_transdimensional.py
+++ b/epsie/proposals/nested_transdimensional.py
@@ -1,0 +1,334 @@
+# Copyright (C) 2020 Richard Stiskalek, Collin Capano
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.  #
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from __future__ import (absolute_import, division)
+
+
+import numpy
+from scipy import stats
+
+try:
+    from randomgen import RandomGenerator
+except ImportError:
+    from randomgen import Generator as RandomGenerator
+
+import epsie
+from .base import BaseProposal
+
+
+class NestedTransdimensional(BaseProposal):
+    """Nested transdimensional proposal.
+
+    Parameters
+    ----------
+    parameters : (list of) str
+        The names of the parameters to produce proposals for.
+    model_proposal : py:class `epsie.proposals`
+        The model hopping proposals. This must be a discrete, bounded proposal.
+    proposals : list of py:class `epsie.proposals`
+        The transdimensional proposals that are being turned on/off.
+    birth_distributions: list of objects
+        Objects that match transdimensional proposals and are used to birth
+        new samples and evaluate their proposal probability. Must use structure
+        as given in the example.
+    bit_generator : :py:class:`epsie.BIT_GENERATOR` instance or int, optional
+        The random bit generator to use, or an integer/None. If the latter, a
+        bit generator will be created using
+        :py:func:`epsie.create_bit_generator`.
+
+    Attributes
+    ----------
+    proposals: list of py:class `epsie.proposals`
+        The constituent in-model proposals.
+    model_proposal: py:class `epsie.proposals.DiscreteBounded
+        The model hopping proposal
+    """
+    name = 'nested_transdimensional'
+    transdimensional = True
+
+    # Py3XX: change kwargs to explicit random_state=None
+    def __init__(self, parameters, model_proposal, proposals,
+                 birth_distributions, **kwargs):
+        self._model_proposal = None
+        self.parameters = parameters
+        bit_generator = kwargs.pop('bit_generator', None)  # Py3XX: delete line
+        self.bit_generator = bit_generator
+        # store the proposals
+        self.setup_proposals(model_proposal, proposals)
+        # store the birth distributions
+        self.setup_births(birth_distributions)
+        self._index = self.model_proposal.parameters[0]
+
+    @property
+    def proposals(self):
+        return self._proposals
+
+    @property
+    def model_proposal(self):
+        return self._model_proposal
+
+    def setup_proposals(self, model_proposal, proposals):
+        # let all proposals share the same random generator
+        for prop in proposals:
+            prop.bit_generator = self.bit_generator
+            # check the proposal parameters
+            if not all(par in self.parameters for par in prop.parameters):
+                raise ValueError("Proposal parameters {} not found "
+                                 " in `parameters`.".format(prop.parameters))
+        # check the model proposal
+        model_proposal.bit_generator = self.bit_generator
+        if len(model_proposal.parameters) > 1:
+            raise ValueError("Model jump proposal should have single param")
+        elif model_proposal.parameters[0] not in self.parameters:
+            raise ValueError("Model jump proposal parameter {} not found in "
+                             "`parameters`.".format(
+                                 model_proposal.parameters[0]))
+
+        self._proposals = numpy.array(proposals)
+        self._model_proposal = model_proposal
+        self._symmetric = (all(prop.symmetric for prop in proposals) and
+                           model_proposal.symmetric)
+
+    def setup_births(self, birth_distributions):
+        """Matches birth distributions to proposals. Note that order of
+        parameters matters"""
+        # check all transdimensional proposals have their birth dists
+        # and match the birth distribution to the given proposal. Also ensure
+        # that no transdimensional proposal has more than a single birth dist
+        for prop in self.proposals:
+            matched = 0
+            for dist in birth_distributions:
+                if prop.parameters == tuple(dist.parameters):
+                    dist.bit_generator = prop.bit_generator
+                    prop.birth_distribution = dist
+                    matched += 1
+            if matched == 0:
+                raise ValueError("Parameters {} miss `birth dist`. Note "
+                                 "that order matters".format(prop.parameters))
+            elif matched > 1:
+                raise ValueError("Parameters {} have multiple"
+                                 "`birth dists`".format(prop.parameters))
+
+    @property
+    def symmetric(self):
+        return self._symmetric
+
+    def logpdf(self, xi, givenx):
+        lp = 0.0
+        # logpdf on the model jump
+        lp += self.model_proposal.logpdf({self._index: xi[self._index]},
+                                         {self._index: givenx[self._index]})
+        # logpdf on the transdimensional moves
+        current_state = givenx['_state']
+        proposed_state = xi['_state']
+        dk = xi[self._index] - givenx[self._index]
+        if dk > 0:
+            mask = numpy.logical_and(numpy.logical_not(current_state),
+                                     proposed_state)
+            for prop in self.proposals[mask]:
+                lp += prop.birth_distribution.logpdf(
+                    {p: xi[p] for p in prop.parameters})
+        # logpdf on transdimensional moves that were only updated
+        for prop in self.proposals[numpy.logical_and(current_state,
+                                                     proposed_state)]:
+            lp += prop.logpdf({p: xi[p] for p in prop.parameters},
+                              {p: givenx[p] for p in prop.parameters})
+        return lp
+
+    def update(self, chain):
+        # check that proposal has been stepped inside at least twice in a row
+        if chain.iteration > 1:
+            for prop in self.proposals:
+                current = chain.positions[-1]
+                if len(chain) == 1:
+                    previous = chain.start_position
+                else:
+                    previous = chain.positions[-2]
+
+                pars = prop.parameters
+                condition1 = not all(numpy.isnan(previous[p]) for p in pars)
+                condition2 = not all(numpy.isnan(current[p]) for p in pars)
+                if condition1 and condition2:
+                    prop.update(chain)
+
+    def jump(self, fromx):
+        current_state = fromx['_state']
+        out = fromx.copy()
+        out.update(self.model_proposal.jump({self._index: fromx[self._index]}))
+
+        dk = out[self._index] - fromx[self._index]
+        if dk != 0:
+            if dk > 0:
+                indx = numpy.where(numpy.logical_not(current_state))[0]
+            elif dk < 0:
+                indx = numpy.where(current_state)[0]
+            # randomly pick which proposals will be turned on/off
+            proposed_state = current_state.copy()
+            mask = self.random_generator.choice(indx, size=abs(dk),
+                                                replace=False).reshape(-1,)
+            proposed_state[mask] = numpy.logical_not(proposed_state[mask])
+            # create the boolean mask for which proposals are being flipped
+            if dk > 0:
+                bd_mask = numpy.logical_and(numpy.logical_not(current_state),
+                                            proposed_state)
+            else:
+                bd_mask = numpy.logical_and(current_state,
+                                            numpy.logical_not(proposed_state))
+            # update the out dictionary
+            for prop in self.proposals[bd_mask]:
+                if dk > 0:
+                    out.update(prop.birth_distribution.birth)
+                elif dk < 0:
+                    out.update({p: numpy.nan for p in prop.parameters})
+        else:
+            proposed_state = current_state
+        # do an update move on all proposals that are not nans/just activated
+        update_mask = numpy.logical_and(current_state, proposed_state)
+        for prop in self.proposals[update_mask]:
+            out.update(prop.jump({p: fromx[p] for p in prop.parameters}))
+        out.update({'_state': proposed_state})
+        return out
+
+    @property
+    def state(self):
+        # get all of the proposals state
+        state = {}
+        birth_state = {}
+        for prop in self.proposals:
+            state.update({frozenset(prop.parameters): prop.state})
+            # Get the random states of birth dists
+            birth_state.update(
+                {frozenset(prop.parameters): prop.birth_distribution.state})
+
+        state.update({'_births': birth_state})
+        state.update({frozenset(self.model_proposal.parameters):
+                      self.model_proposal.state})
+        # add the global random state
+        state['random_state'] = self.random_state
+        return state
+
+    def set_state(self, state):
+        # set each proposals' state, birth dist's state and proposal counters
+        for prop in self.proposals:
+            prop.set_state(state[frozenset(prop.parameters)])
+            prop.birth_distribution.set_state(
+                state['_births'][frozenset(prop.parameters)])
+
+        self.model_proposal.set_state(state[frozenset(
+            self.model_proposal.parameters)])
+        # set the state of the random number generator
+        self.random_state = state['random_state']
+
+
+class UniformBirthDistribution(object):
+    """Birth distribution object used in nested transdimensional proposals
+    to propose birth to parameters which were previously inactive. This
+    particular implementation assumes a uniform proposal distribution.
+
+    Parameters
+    ----------
+    parameters : (list of) str
+        The names of the parameters to produce proposals for.
+    boundaries : dict
+        Dictionary mapping parameters to boundaries. Boundaries must be a
+        tuple or iterable of length two.
+
+    Properties
+    ----------
+    birth : dict
+        Returns random variate sample from the uniform distribution for each
+        parameter.
+
+    Methods
+    ------
+    logpdf : py:func
+        Evalues the logpdf proposal ratio. Takes dictionary of parameters as
+        input.
+    """
+    name = 'uniform_birth_distribution'
+    _random_generator = None
+    _bit_generator = None
+
+    def __init__(self, parameters, bounds):
+        self.parameters = parameters
+        self.bounds = bounds
+        self.scale = {p: bounds[p][1] - bounds[p][0] for p in parameters}
+
+    @property
+    def bit_generator(self):
+        """The random bit generator instance being used.
+        """
+        try:
+            return self._bit_generator
+        except AttributeError:
+            self._bit_generator = epsie.create_bit_generator()
+            return self._bit_generator
+
+    @bit_generator.setter
+    def bit_generator(self, bit_generator):
+        """Sets the random bit generator.
+
+        Parameters
+        ----------
+        bit_generator : :py:class:`epsie.BIT_GENERATOR`, int, or None
+            Either the bit generator to use or an integer/None. If the latter,
+            a generator will be created by passing ``bit_generator`` as the
+            ``seed`` argument to :py:func:`epsie.create_bit_generator`.
+        """
+        if not isinstance(bit_generator, epsie.BIT_GENERATOR):
+            bit_generator = epsie.create_bit_generator(bit_generator)
+        self._bit_generator = bit_generator
+
+    @property
+    def random_generator(self):
+        """The random number generator.
+
+        This is an instance of :py:class:`randgen.RandomGenerator` that is
+        derived from the bit generator. It provides methods to create random
+        draws from various distributions.
+        """
+        return RandomGenerator(self.bit_generator)
+
+    @property
+    def random_state(self):
+        """The current state of the random bit generator.
+        """
+        return self.bit_generator.state
+
+    @random_state.setter
+    def random_state(self, state):
+        """Sets the state of bit_generator.
+        Parameters
+        ----------
+        state : dict
+            Dictionary giving the state to set.
+        """
+        self.bit_generator.state = state
+
+    @property
+    def state(self):
+        return {'random_state': self.random_state}
+
+    def set_state(self, state):
+        self.random_state = state['random_state']
+
+    @property
+    def birth(self):
+        return {p: self.random_generator.uniform(
+            self.bounds[p][0], self.bounds[p][1]) for p in self.parameters}
+
+    def logpdf(self, xi):
+        return sum([stats.uniform.logpdf(
+            xi[p], loc=self.bounds[p][0], scale=self.scale[p])
+            for p in self.parameters])

--- a/test/test_nested_transdimensional.py
+++ b/test/test_nested_transdimensional.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2020  Richard Stiskalek, Collin Capano
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 3 of the License, or (at your
+# option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+"""Performs unit tests on the NestedTransdimensional proposal."""
+from __future__ import (print_function, absolute_import)
+
+import numpy
+import pytest
+
+
+from epsie.proposals import (NestedTransdimensional, BoundedDiscrete, Normal,
+                             SSAdaptiveNormal, AdaptiveNormal,
+                             AdaptiveProposal, UniformBirthDistribution)
+from _utils import PolynomialRegressionModel
+from epsie import make_betas_ladder
+
+from test_ptsampler import _create_sampler
+# from test_ptsampler import test_chains as _test_chains
+from test_ptsampler import test_checkpointing as _test_checkpointing
+from test_ptsampler import test_seed as _test_seed
+from test_ptsampler import test_clear_memory as _test_clear_memory
+
+
+ITERINT = 64
+ADAPTATION_DURATION = ITERINT//2
+SWAP_INTERVAL = 1
+
+
+def _setup_proposal(model, td_proposal, cov=None):
+    # Initialise the birth-objects for transdimensional parameters
+    birth_dists = [UniformBirthDistribution(['a{}'.format(i)],
+                                            {'a{}'.format(i): (-2., 2.)})
+                   for i in range(1, 5+1)]
+    # Initialies transdimensional proposals
+    if td_proposal == 'normal':
+        td_proposals = [Normal(['a{}'.format(i)], cov=cov)
+                        for i in range(1, 5+1)]
+    elif td_proposal == 'adaptive_normal':
+        widths = {'a{}'.format(i): 4 for i in range(1, 6)}
+        td_proposals = [
+            AdaptiveNormal(['a{}'.format(i)], widths, ADAPTATION_DURATION)
+            for i in range(1, 5+1)]
+    elif td_proposal == 'ss_adaptive_normal':
+        td_proposals = [SSAdaptiveNormal(['a{}'.format(i)])
+                        for i in range(1, 5+1)]
+    elif td_proposal == 'adaptive_proposal':
+        td_proposals = [AdaptiveProposal(['a{}'.format(i)])
+                        for i in range(1, 5+1)]
+
+    # Model hopping proposal
+    model_proposal = BoundedDiscrete(['k'],
+                                     boundaries={'k': (0, len(td_proposals))},
+                                     successive={'k': True})
+    pars = ['a{}'.format(i) for i in range(1, 5+1)] + ['k']
+    # Initialise the bundle transdimemnsional proposal
+    return NestedTransdimensional(pars, model_proposal, td_proposals,
+                                  birth_dists)
+
+
+@pytest.mark.parametrize('td_proposal', ['normal', 'adaptive_normal',
+                                         'ss_adaptive_normal',
+                                         'adaptive_proposal'])
+@pytest.mark.parametrize('nprocs', [1, 4])
+@pytest.mark.parametrize('nchains', [1, 4])
+@pytest.mark.parametrize('ntemps', [2, 3])
+def test_active_parameters(td_proposal, nprocs, nchains, ntemps, model=None):
+    """Tests that the standard deviation changes after a few jumps for the type
+    of proposal specified by ``proposal_name``.
+    """
+    # use the test model
+    if model is None:
+        model = PolynomialRegressionModel()
+    proposal = _setup_proposal(model, td_proposal)
+    # we'll just use the PTSampler default setup from the ptsampler tests
+    betas = make_betas_ladder(ntemps, 1e3)
+    sampler = _create_sampler(model, nprocs, nchains=nchains, betas=betas,
+                              proposals=[proposal])
+    sampler.run(ITERINT)
+    # check that the model index matched the number of finite parameters
+    # at each turn
+    for n in range(sampler.niterations):
+        for i in range(nchains):
+            for j in range(ntemps):
+                coeffs = numpy.array([
+                    sampler.positions[j, i, n]['a{}'.format(m)]
+                    for m in range(1, 5 + 1)])
+                k = sampler.positions[j, i, n]['k']
+                assert numpy.isfinite(coeffs).sum() == k
+
+
+@pytest.mark.parametrize('td_proposal', ['normal', 'adaptive_normal',
+                                         'ss_adaptive_normal',
+                                         'adaptive_proposal'])
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_checkpointing(td_proposal, nprocs):
+    """Performs the same checkpointing test as for the PTSampler, but using
+    the adaptive normal proposal.
+    """
+    model = PolynomialRegressionModel()
+    proposal = _setup_proposal(model, td_proposal)
+    _test_checkpointing(PolynomialRegressionModel, nprocs,
+                        proposals=[proposal])
+
+
+@pytest.mark.parametrize('td_proposal', ['normal', 'adaptive_normal',
+                                         'ss_adaptive_normal',
+                                         'adaptive_proposal'])
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_seed(td_proposal, nprocs):
+    """Runs the PTSampler ``test_seed`` using the adaptive normal proposal.
+    """
+    model = PolynomialRegressionModel()
+    proposal = _setup_proposal(model, td_proposal)
+    _test_seed(PolynomialRegressionModel, nprocs, proposals=[proposal])
+
+
+@pytest.mark.parametrize('td_proposal', ['normal', 'adaptive_normal',
+                                         'ss_adaptive_normal',
+                                         'adaptive_proposal'])
+@pytest.mark.parametrize('nprocs', [1, 4])
+def test_clear_memory(td_proposal, nprocs):
+    """Runs the PTSampler ``test_clear_memoory`` using the adaptive normal
+    proposal.
+    """
+    model = PolynomialRegressionModel()
+    proposal = _setup_proposal(model, td_proposal)
+    _test_clear_memory(PolynomialRegressionModel, nprocs, SWAP_INTERVAL,
+                       proposals=[proposal])


### PR DESCRIPTION
* add birthdeath proposal

* add .active support

* fix active proposal bug

* add suport for lists of act/inact props

* attempt at fixing PT bug

* rename files

* add reverse jump back

* Include multiple layesr jump

* update proposal description

* fix minor bugs in reverse jump

* hold list of active props

* working version for non-pt

* quick hack to allow parallel tempering

* make active proposals attributes of the chain

* working PT

* pep 8 issues

* more support for list of propols

* PT sampler + correct RJMCMC logpdf

* fix pep8

* fix overindent

* stop repeating in _start_pos blocks of code and store state in pos

* make transdimensional attribute of the base sampler

* remove 1/k factors

* stop requiring `transdimensional` argument

* remove assumption of all model proposals being the same

* rename

* remove transdimensinal list

* add suport for having global proposals

* add birth distributions support

* example notebook

* Support in chain for both standard and transdim proposals

* add support for vanishing decay RJMCMC

* fix renaming of a chain active props in ptchain

* test unit test

* test travis

* fix python2 RandomGenerator import

* finalise the unit test

* final pep8 checks

* move UniformBirthDistribution to nested_transdimensional.py

* chain when starting from state learn _positions dtypes from starting point

* do numpy.testing.assert_equal to compare positions in case some are NaNs

* add a way for proposals to keep track of number of steps within each model if transdimensional

* add unit tests for adaptation, seed, checkpoint and clear memory

* fix minor issues and pep8

* remove unwanted comments

* change some imports

* Make `nsteps` proposal attribute

* fix pep8

* Make base proposal keep nsteps

* pep8 comment issue